### PR TITLE
fix referential integrity bug, optimize to be more join-y

### DIFF
--- a/src/matrix_validator/checks/check_edge_ids_in_node_ids.py
+++ b/src/matrix_validator/checks/check_edge_ids_in_node_ids.py
@@ -9,37 +9,32 @@ def validate(df, edge_ids: list, column: str):
     """Validate that all edge subject/object IDs exist in Nodes."""
     # Create a dataframe from edge IDs with a column name matching the nodes dataframe
     edge_df = pl.DataFrame({column: edge_ids})
-    
+
     # Use an anti-join to find missing edge IDs (edge IDs not in node IDs)
     # This is highly efficient as it uses hashing internally
     missing_df = edge_df.join(df.select(pl.col(column)), on=column, how="anti")
-    
+
     # If no violations, return early
     if missing_df.height == 0:
         return ""
-    
+
     # Rename the column for consistency with the rest of the function
     violations_df = missing_df.rename({column: "invalid_edge_ids_in_node_ids"})
-    
+
     # For very large results, sample for reporting
     if violations_df.height > 1000:
         violations_df = violations_df.sample(1000, seed=42)
-    
+
     # Count total violations (from the original anti-join)
     total_violations = missing_df.height
-    
+
     # Group violations by prefix (extract prefix from before the colon)
-    with_prefix = violations_df.with_columns(
-        pl.col("invalid_edge_ids_in_node_ids").str.split(":").list.first().alias("prefix")
-    )
+    with_prefix = violations_df.with_columns(pl.col("invalid_edge_ids_in_node_ids").str.split(":").list.first().alias("prefix"))
 
     # Group by prefix and count
     prefix_counts = (
         with_prefix.group_by("prefix")
-        .agg(
-            pl.len().alias("count"), 
-            pl.col("invalid_edge_ids_in_node_ids").head(3).alias("examples")
-        )
+        .agg(pl.len().alias("count"), pl.col("invalid_edge_ids_in_node_ids").head(3).alias("examples"))
         .sort("count", descending=True)
     )
 

--- a/src/matrix_validator/checks/check_edge_ids_in_node_ids.py
+++ b/src/matrix_validator/checks/check_edge_ids_in_node_ids.py
@@ -6,28 +6,40 @@ import polars as pl
 
 
 def validate(df, edge_ids: list, column: str):
-    """Validate contains Edge subject/object exist in Nodes."""
-    violations_df = df.select(
-        [
-            pl.when(~pl.col(column).str.contains_any(edge_ids))
-            .then(pl.col(column))
-            .otherwise(pl.lit(None))
-            .alias("invalid_edge_ids_in_node_ids"),
-        ]
-    ).filter(pl.col("invalid_edge_ids_in_node_ids").is_not_null())
-
-    # Count total violations
-    total_violations = len(violations_df)
-    if total_violations == 0:
+    """Validate that all edge subject/object IDs exist in Nodes."""
+    # Create a dataframe from edge IDs with a column name matching the nodes dataframe
+    edge_df = pl.DataFrame({column: edge_ids})
+    
+    # Use an anti-join to find missing edge IDs (edge IDs not in node IDs)
+    # This is highly efficient as it uses hashing internally
+    missing_df = edge_df.join(df.select(pl.col(column)), on=column, how="anti")
+    
+    # If no violations, return early
+    if missing_df.height == 0:
         return ""
-
+    
+    # Rename the column for consistency with the rest of the function
+    violations_df = missing_df.rename({column: "invalid_edge_ids_in_node_ids"})
+    
+    # For very large results, sample for reporting
+    if violations_df.height > 1000:
+        violations_df = violations_df.sample(1000, seed=42)
+    
+    # Count total violations (from the original anti-join)
+    total_violations = missing_df.height
+    
     # Group violations by prefix (extract prefix from before the colon)
-    with_prefix = violations_df.with_columns(pl.col("invalid_edge_ids_in_node_ids").str.split(":").list.first().alias("prefix"))
+    with_prefix = violations_df.with_columns(
+        pl.col("invalid_edge_ids_in_node_ids").str.split(":").list.first().alias("prefix")
+    )
 
     # Group by prefix and count
     prefix_counts = (
         with_prefix.group_by("prefix")
-        .agg(pl.count().alias("count"), pl.col("invalid_edge_ids_in_node_ids").head(3).alias("examples"))
+        .agg(
+            pl.len().alias("count"), 
+            pl.col("invalid_edge_ids_in_node_ids").head(3).alias("examples")
+        )
         .sort("count", descending=True)
     )
 

--- a/src/matrix_validator/validator_polars.py
+++ b/src/matrix_validator/validator_polars.py
@@ -359,7 +359,7 @@ class ValidatorPolarsImpl(Validator):
 
         # Check if there are missing node IDs referenced in edges
         if counts_df.get_column("invalid_edge_ids_in_node_ids_count").item(0) > 0:
-            validation_reports.append(check_edge_ids_in_node_ids(nodes_df, unique_edge_ids, nodes))
+            validation_reports.append(check_edge_ids_in_node_ids(nodes_df, unique_edge_ids, "id"))
 
         # Analyze edge types
         logger.info("Analyzing edge types")


### PR DESCRIPTION
Fixes an error in the referential integity check (subject & object show up as node ids) and then works past a performance bottleneck that came up by using an antijoin. 